### PR TITLE
fix the base image URI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.centos.org/sclo/nodejs-6-centos7:latest
+FROM registry.centos.org/centos/nodejs-6-centos7:latest
 
 # Install dependencies for mattermost-integration-github
 RUN git clone https://github.com/gorkem/penfold &&\


### PR DESCRIPTION
The base image for this has to be moved,
from: registry.centos.org/sclo/nodejs-6-centos7:latest
to:   registry.centos.org/centos/nodejs-6-centos7:latest