### PR TITLE
Modify standup command to only trigger when standup is first word

### DIFF
--- a/penfold.ts
+++ b/penfold.ts
@@ -61,7 +61,7 @@ function Penfold(robot: any) {
     resp.send('hello');
   });
 
-	robot.hear(/\!*standup/i, (res: any) => {
+	robot.hear(/^\!*standup/i, (res: any) => {
     standupService.receive(new Response(res));
 	});
 


### PR DESCRIPTION
**Note**: I only tested locally in the terminal, but the modified regex should still work for multiline messages.

Saying the word standup in a message replaces your standup, and it only includes the words after the standup keyword. This changes the regex to only match when standup is the first word (with optional `!` chars)