### PR TITLE
moved from deprecated "legacy" to "inspector" debug protocol

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "name": "Attach to Hubot",
             "sourceMaps": true,
 			      "outFiles": [ "${workspaceRoot}/scripts/**/*.js" ],
-			      "protocol": "legacy"
+			      "protocol": "inspector"
         }
     ]
 }


### PR DESCRIPTION
as of nodejs 8 "legacy" protocol was deprecated.
See https://nodejs.org/en/docs/guides/debugging-getting-started/#legacy-debugger